### PR TITLE
fix(cache): build RuntimeInfo from the worker tiered store

### DIFF
--- a/pkg/ddc/cache/engine/runtime.go
+++ b/pkg/ddc/cache/engine/runtime.go
@@ -97,7 +97,8 @@ func (e *CacheEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 		// keep the same as base.GetRuntimeInfo
 		opts := []base.RuntimeInfoOption{
-			base.WithTieredStore(datav1alpha1.TieredStore{}),
+			// used for the cache capacity labels put on nodes running worker pods
+			base.WithTieredStore(convertToLegacyTieredStore(runtime.Spec.Worker.TieredStore)),
 			// below used for create volume
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
 			base.WithAnnotations(runtime.Annotations),

--- a/pkg/ddc/cache/engine/transform_tiered_store.go
+++ b/pkg/ddc/cache/engine/transform_tiered_store.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -255,4 +256,76 @@ func withTieredStoreMemoryQuota(base corev1.ResourceRequirements, quota resource
 		}
 	}
 	return result
+}
+
+// convertToLegacyTieredStore converts a CacheRuntime RuntimeTieredStore into the legacy
+// TieredStore that base.BuildRuntimeInfo consumes. RuntimeInfo holds a single TieredStoreInfo
+// and drives the cache capacity labels put on nodes, so it is fed from the worker tiered store
+// only: labelling is keyed off nodes running worker pods (getDesiredNodesWithScheduleInfo), and
+// a client tier would therefore be counted on nodes where a worker happens to co-reside and
+// silently dropped everywhere else.
+//
+// The two APIs describe the storage medium differently. RuntimeTieredStoreLevel names it
+// structurally through ProcessMemory, EmptyDir and HostPath, while the legacy Level carries an
+// explicit MEM/SSD/HDD enum. Only the memory-versus-disk distinction survives, which is what the
+// consumers need: tieredstore.GetLevelStorageMap buckets SSD and HDD together. Disk-backed levels
+// are reported as HDD to match the medium type already written into the runtime config ConfigMap
+// by extractTieredStoreLevels.
+//
+// The media are examined in the same order as TransformRuntimeTieredStore - memory, host path,
+// empty dir - so that the two functions agree on which one wins should a level ever name more
+// than the single medium the API allows.
+//
+// A level naming no medium is skipped rather than emitted. convertToTieredstoreInfo rejects a
+// Level carrying neither Quota nor QuotaList, and that error propagates through WithTieredStore
+// and BuildRuntimeInfo out of getRuntimeInfo, which would fail the whole reconcile.
+func convertToLegacyTieredStore(tieredStore datav1alpha1.RuntimeTieredStore) datav1alpha1.TieredStore {
+	legacyTieredStore := datav1alpha1.TieredStore{}
+
+	for levelIndex, level := range tieredStore.Levels {
+		legacyLevel := datav1alpha1.Level{
+			High: level.High,
+			Low:  level.Low,
+		}
+
+		switch {
+		case level.ProcessMemory != nil:
+			quota := level.ProcessMemory.Quota.DeepCopy()
+			legacyLevel.MediumType = common.Memory
+			legacyLevel.Path = GetMemoryTieredStoreMountPath(levelIndex)
+			legacyLevel.Quota = &quota
+		case level.HostPath != nil:
+			// Paths and Quotas are parallel lists. The CRD requires both to be non-empty but
+			// cannot express that they must have the same length, so guard here: a mismatch
+			// would otherwise be rejected by convertToTieredstoreInfo.
+			if len(level.HostPath.Paths) == 0 || len(level.HostPath.Paths) != len(level.HostPath.Quotas) {
+				continue
+			}
+			paths := make([]string, 0, len(level.HostPath.Paths))
+			quotas := make([]string, 0, len(level.HostPath.Quotas))
+			for pathIndex := range level.HostPath.Paths {
+				paths = append(paths, GetHostPathTieredStoreMountPath(levelIndex, pathIndex))
+				quotas = append(quotas, level.HostPath.Quotas[pathIndex].String())
+			}
+			legacyLevel.MediumType = common.HDD
+			// Per-path quotas must be kept apart: a single Quota would be divided equally over
+			// the paths by convertToTieredstoreInfo and lose the declared distribution.
+			legacyLevel.Path = strings.Join(paths, ",")
+			legacyLevel.QuotaList = strings.Join(quotas, ",")
+		case level.EmptyDir != nil:
+			quota := level.EmptyDir.Quota.DeepCopy()
+			legacyLevel.MediumType = common.HDD
+			if level.EmptyDir.Medium == corev1.StorageMediumMemory {
+				legacyLevel.MediumType = common.Memory
+			}
+			legacyLevel.Path = GetEmptyDirTieredStoreMountPath(levelIndex)
+			legacyLevel.Quota = &quota
+		default:
+			continue
+		}
+
+		legacyTieredStore.Levels = append(legacyTieredStore.Levels, legacyLevel)
+	}
+
+	return legacyTieredStore
 }

--- a/pkg/ddc/cache/engine/transform_tiered_store_test.go
+++ b/pkg/ddc/cache/engine/transform_tiered_store_test.go
@@ -23,6 +23,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/tieredstore"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -531,6 +534,153 @@ var _ = Describe("CacheEngine TransformRuntimeTieredStore Tests", Label("pkg.ddc
 
 			quota := chargedTieredStoreMemoryQuota(podSpec)
 			Expect(quota.String()).To(Equal("8Gi"))
+		})
+	})
+})
+
+var _ = Describe("CacheEngine convertToLegacyTieredStore Tests", Label("pkg.ddc.cache.engine.transform_tiered_store_test.go"), func() {
+	Describe("convertToLegacyTieredStore", func() {
+		It("should return no levels for an unset tiered store", func() {
+			Expect(convertToLegacyTieredStore(datav1alpha1.RuntimeTieredStore{}).Levels).To(BeEmpty())
+		})
+
+		It("should map process memory to the MEM medium", func() {
+			legacy := convertToLegacyTieredStore(datav1alpha1.RuntimeTieredStore{
+				Levels: []datav1alpha1.RuntimeTieredStoreLevel{
+					{
+						ProcessMemory: &datav1alpha1.ProcessMemoryMediumSource{
+							Quota: resource.MustParse("4Gi"),
+						},
+						High: "0.8",
+						Low:  "0.5",
+					},
+				},
+			})
+
+			Expect(legacy.Levels).To(HaveLen(1))
+			Expect(legacy.Levels[0].MediumType).To(Equal(common.Memory))
+			Expect(legacy.Levels[0].Path).To(Equal(GetMemoryTieredStoreMountPath(0)))
+			Expect(legacy.Levels[0].Quota.String()).To(Equal("4Gi"))
+			Expect(legacy.Levels[0].High).To(Equal("0.8"))
+			Expect(legacy.Levels[0].Low).To(Equal("0.5"))
+		})
+
+		It("should map a memory backed emptyDir to the MEM medium", func() {
+			legacy := convertToLegacyTieredStore(datav1alpha1.RuntimeTieredStore{
+				Levels: []datav1alpha1.RuntimeTieredStoreLevel{
+					{
+						EmptyDir: &datav1alpha1.EmptyDirMediumSource{
+							Quota:  resource.MustParse("2Gi"),
+							Medium: corev1.StorageMediumMemory,
+						},
+					},
+				},
+			})
+
+			Expect(legacy.Levels).To(HaveLen(1))
+			Expect(legacy.Levels[0].MediumType).To(Equal(common.Memory))
+			Expect(legacy.Levels[0].Quota.String()).To(Equal("2Gi"))
+		})
+
+		It("should map a default emptyDir to a disk medium", func() {
+			legacy := convertToLegacyTieredStore(datav1alpha1.RuntimeTieredStore{
+				Levels: []datav1alpha1.RuntimeTieredStoreLevel{
+					{
+						EmptyDir: &datav1alpha1.EmptyDirMediumSource{
+							Quota: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			})
+
+			Expect(legacy.Levels).To(HaveLen(1))
+			Expect(legacy.Levels[0].MediumType).To(Equal(common.HDD))
+			Expect(legacy.Levels[0].Path).To(Equal(GetEmptyDirTieredStoreMountPath(0)))
+			Expect(legacy.Levels[0].Quota.String()).To(Equal("1Gi"))
+		})
+
+		It("should keep host path quotas per path instead of collapsing them into one", func() {
+			legacy := convertToLegacyTieredStore(datav1alpha1.RuntimeTieredStore{
+				Levels: []datav1alpha1.RuntimeTieredStoreLevel{
+					{
+						HostPath: &datav1alpha1.HostPathMediumSource{
+							Paths:  []string{"/mnt/cache1", "/mnt/cache2"},
+							Quotas: []resource.Quantity{resource.MustParse("1Gi"), resource.MustParse("3Gi")},
+						},
+					},
+				},
+			})
+
+			Expect(legacy.Levels).To(HaveLen(1))
+			Expect(legacy.Levels[0].MediumType).To(Equal(common.HDD))
+			Expect(legacy.Levels[0].Path).To(Equal(
+				GetHostPathTieredStoreMountPath(0, 0) + "," + GetHostPathTieredStoreMountPath(0, 1)))
+			Expect(legacy.Levels[0].QuotaList).To(Equal("1Gi,3Gi"))
+			Expect(legacy.Levels[0].Quota).To(BeNil())
+		})
+
+		It("should skip a host path level whose paths and quotas disagree in length", func() {
+			legacy := convertToLegacyTieredStore(datav1alpha1.RuntimeTieredStore{
+				Levels: []datav1alpha1.RuntimeTieredStoreLevel{
+					{
+						HostPath: &datav1alpha1.HostPathMediumSource{
+							Paths:  []string{"/mnt/cache1", "/mnt/cache2"},
+							Quotas: []resource.Quantity{resource.MustParse("1Gi")},
+						},
+					},
+				},
+			})
+
+			Expect(legacy.Levels).To(BeEmpty())
+		})
+
+		It("should skip a level that names no medium", func() {
+			legacy := convertToLegacyTieredStore(datav1alpha1.RuntimeTieredStore{
+				Levels: []datav1alpha1.RuntimeTieredStoreLevel{
+					{High: "0.9"},
+					{EmptyDir: &datav1alpha1.EmptyDirMediumSource{Quota: resource.MustParse("1Gi")}},
+				},
+			})
+
+			Expect(legacy.Levels).To(HaveLen(1))
+			Expect(legacy.Levels[0].Quota.String()).To(Equal("1Gi"))
+		})
+
+		It("should keep the declared order and index paths per level", func() {
+			legacy := convertToLegacyTieredStore(datav1alpha1.RuntimeTieredStore{
+				Levels: []datav1alpha1.RuntimeTieredStoreLevel{
+					{ProcessMemory: &datav1alpha1.ProcessMemoryMediumSource{Quota: resource.MustParse("4Gi")}},
+					{EmptyDir: &datav1alpha1.EmptyDirMediumSource{Quota: resource.MustParse("1Gi")}},
+				},
+			})
+
+			Expect(legacy.Levels).To(HaveLen(2))
+			Expect(legacy.Levels[0].MediumType).To(Equal(common.Memory))
+			Expect(legacy.Levels[1].MediumType).To(Equal(common.HDD))
+			Expect(legacy.Levels[1].Path).To(Equal(GetEmptyDirTieredStoreMountPath(1)))
+		})
+	})
+
+	Describe("the result feeding base.BuildRuntimeInfo", func() {
+		It("should produce levels that convertToTieredstoreInfo accepts and sums correctly", func() {
+			legacy := convertToLegacyTieredStore(datav1alpha1.RuntimeTieredStore{
+				Levels: []datav1alpha1.RuntimeTieredStoreLevel{
+					{ProcessMemory: &datav1alpha1.ProcessMemoryMediumSource{Quota: resource.MustParse("4Gi")}},
+					{HostPath: &datav1alpha1.HostPathMediumSource{
+						Paths:  []string{"/mnt/cache1", "/mnt/cache2"},
+						Quotas: []resource.Quantity{resource.MustParse("1Gi"), resource.MustParse("3Gi")},
+					}},
+				},
+			})
+
+			runtimeInfo, err := base.BuildRuntimeInfo("test", "default", common.CacheRuntime,
+				base.WithTieredStore(legacy))
+			Expect(err).NotTo(HaveOccurred())
+
+			storage := tieredstore.GetLevelStorageMap(runtimeInfo)
+			Expect(storage[common.MemoryCacheStore].String()).To(Equal("4Gi"))
+			// 1Gi and 3Gi must survive as 4Gi rather than being averaged to 2Gi each
+			Expect(storage[common.DiskCacheStore].String()).To(Equal("4Gi"))
 		})
 	})
 })


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`CacheEngine.getRuntimeInfo` built its `RuntimeInfo` with an empty `TieredStore`, so `convertToTieredstoreInfo` returned no levels, `GetLevelStorageMap` returned an empty map, and `labelNodeWithCapacityInfo` never added the memory or disk capacity labels while writing the total one unconditionally as `0B`. A CacheRuntime declaring a real tiered store advertised no cache capacity on any node it landed on.

Every other engine passes its runtime's tiered store here; CacheRuntime was the only one passing a zero value, because `RuntimeTieredStore` and the legacy `TieredStore` that `base.WithTieredStore` consumes describe the storage medium differently and no conversion existed.

This PR adds `convertToLegacyTieredStore` to bridge the two, and wires it into `getRuntimeInfo`.

Two points from the issue that were product decisions rather than mechanical ones:

- **Medium mapping.** The legacy `Level` carries an explicit `MEM`/`SSD`/`HDD` enum while `RuntimeTieredStoreLevel` names the medium structurally through `ProcessMemory`, `EmptyDir` and `HostPath`. Only the memory-versus-disk distinction survives, which is all the consumers need — `GetLevelStorageMap` buckets `SSD` and `HDD` together. Disk-backed levels are reported as `HDD`, matching the medium type `extractTieredStoreLevels` already writes into the runtime config ConfigMap.
- **Whether the client tier counts.** No. Only the worker tiered store feeds `RuntimeInfo`. Nodes are labelled off worker pod placement in `getDesiredNodesWithScheduleInfo`, so a client tier would be counted on nodes where a worker happens to co-reside and silently dropped everywhere else.

Host path levels are converted through `QuotaList` rather than `Quota`, so per-path quotas keep their declared distribution instead of being averaged across the paths by `convertToTieredstoreInfo`.

### Ⅱ. Does this pull request fix one issue?

fixes #6174

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

Unit tests for `convertToLegacyTieredStore` in `pkg/ddc/cache/engine/transform_tiered_store_test.go`, covering:

- an unset `RuntimeTieredStore` producing no levels
- `ProcessMemory` mapping to `MEM` with the `/dev/shm` path, and the `high` / `low` watermarks carried through
- `EmptyDir` with `medium: Memory` mapping to `MEM`, and with the default medium to a disk medium
- `HostPath` keeping its per-path quotas instead of collapsing them into one
- a `HostPath` level whose `paths` and `quotas` disagree in length being skipped rather than emitted
- a level naming no medium being skipped
- multiple levels keeping their declared order, with paths indexed per level

Plus one test that feeds the result through `convertToTieredstoreInfo` to check the levels are accepted and their quotas summed correctly, which is the actual path from this conversion to the node labels.

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/ddc/cache/engine/... ./pkg/ddc/base/... -gcflags=all=-l
```

End to end, with the CacheRuntime from the issue:

```yaml
spec:
  worker:
    replicas: 2
    tieredStore:
      levels:
      - emptyDir: {quota: 1Gi}
        high: "0.8"
        low: "0.5"
```

```bash
kubectl get node <node> -o json | jq '.metadata.labels | with_entries(select(.key | contains("fluid.io")))'
```

`fluid.io/s-h-cache-t-default-mooncake-demo` now reports `1GiB` instead of `0B`, and `fluid.io/s-h-cache-d-default-mooncake-demo` is present. Switching the level to `emptyDir: {quota: 1Gi, medium: Memory}` or to `processMemory: {quota: 1Gi}` yields `fluid.io/s-h-cache-m-...` instead.

### Ⅴ. Special notes for reviews

The capacity labels are written once, when a node first enters the cache node set: `calculateNodeDifferences` only visits newly added nodes, and `addScheduleInfoToNode` skips a node that already carries the runtime label. A CacheRuntime that existed before this change therefore keeps its `0B` label until it is recreated. Worth deciding separately whether that is worth addressing.

Note this is a separate problem from the tiered store memory quota being dropped from the worker memory limit (#6166, fixed by #6167): that one concerns the container's memory accounting, this one concerns the node labels. They share the `tieredStore` spec field but neither fix depends on the other.
