### PR TITLE
fix(cache): complete a partial runtime version from the class template

### DIFF
--- a/pkg/ddc/cache/engine/sync.go
+++ b/pkg/ddc/cache/engine/sync.go
@@ -194,7 +194,7 @@ func (e *CacheEngine) syncRuntimeSpec(ctx cruntime.ReconcileRequestContext, runt
 		}
 		manager := component.NewComponentHelper(common.ComponentTypeMaster, e.Client)
 		masterSpec := component.ComponentSpec{
-			Version:   runtime.Spec.Master.RuntimeVersion,
+			Version:   desiredComponentVersion(runtime.Spec.Master.RuntimeVersion, componentTemplateImage(runtimeClass.Topology.Master)),
 			Resources: desiredComponentResources(runtime.Spec.Master.Resources, runtimeClass.Topology.Master),
 			Replicas:  &runtime.Spec.Master.Replicas,
 		}
@@ -231,7 +231,7 @@ func (e *CacheEngine) syncRuntimeSpec(ctx cruntime.ReconcileRequestContext, runt
 		}
 
 		workerSpec := component.ComponentSpec{
-			Version:   runtime.Spec.Worker.RuntimeVersion,
+			Version:   desiredComponentVersion(runtime.Spec.Worker.RuntimeVersion, componentTemplateImage(runtimeClass.Topology.Worker)),
 			Resources: workerResources,
 			Replicas:  &runtime.Spec.Worker.Replicas,
 		}

--- a/pkg/ddc/cache/engine/transform_common.go
+++ b/pkg/ddc/cache/engine/transform_common.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"fmt"
+	"strings"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -119,9 +120,11 @@ func (e *CacheEngine) transformComponentPodTemplate(runtimeCompSpec datav1alpha1
 
 	// transform container related config, currently only modify the first container
 	if len(podTemplate.Spec.Containers) > 0 {
-		// transform Container Image name etc.
-		if len(runtimeCompSpec.RuntimeVersion.Image) > 0 && len(runtimeCompSpec.RuntimeVersion.ImageTag) > 0 {
-			podTemplate.Spec.Containers[0].Image = runtimeCompSpec.RuntimeVersion.Image + ":" + runtimeCompSpec.RuntimeVersion.ImageTag
+		// transform Container Image name etc. A version naming only one of image and imageTag
+		// takes the other half from the template rather than being dropped.
+		version := desiredComponentVersion(runtimeCompSpec.RuntimeVersion, podTemplate.Spec.Containers[0].Image)
+		if len(version.Image) > 0 && len(version.ImageTag) > 0 {
+			podTemplate.Spec.Containers[0].Image = version.Image + ":" + version.ImageTag
 		}
 		if len(runtimeCompSpec.RuntimeVersion.ImagePullPolicy) > 0 {
 			podTemplate.Spec.Containers[0].ImagePullPolicy = (corev1.PullPolicy)(runtimeCompSpec.RuntimeVersion.ImagePullPolicy)
@@ -147,4 +150,63 @@ func (e *CacheEngine) transformComponentPodTemplate(runtimeCompSpec datav1alpha1
 	if len(componentValue.PodTemplateSpec.Spec.InitContainers) > 0 {
 		componentValue.PodTemplateSpec.Spec.InitContainers[0].Env = append(addEnvs, componentValue.PodTemplateSpec.Spec.InitContainers[0].Env...)
 	}
+}
+
+// desiredComponentVersion completes a partially specified runtime version against the image
+// carried by the CacheRuntimeClass template.
+//
+// VersionSpec declares image and imageTag as independent optional strings, so naming only one
+// of them is a legal way to say "the same image on a newer tag". Both the creation path and
+// updateImage used to require both halves and otherwise leave the template image alone, which
+// silently discards that edit. Completing the missing half here gives both paths the same
+// desired image, so a component created with a partial version and one updated to it end up
+// identical instead of rolling on the next reconcile.
+//
+// A version naming neither half is returned untouched, leaving the template image in place. So
+// is one whose missing half cannot be recovered - a template with no image, or an image pinned
+// by digest - because guessing there would move the workload onto something nobody asked for.
+func desiredComponentVersion(runtimeVersion datav1alpha1.VersionSpec, templateImage string) datav1alpha1.VersionSpec {
+	if runtimeVersion.Image == "" && runtimeVersion.ImageTag == "" {
+		return runtimeVersion
+	}
+	if runtimeVersion.Image != "" && runtimeVersion.ImageTag != "" {
+		return runtimeVersion
+	}
+
+	templateRepository, templateTag := splitImageReference(templateImage)
+	if runtimeVersion.Image == "" {
+		runtimeVersion.Image = templateRepository
+	}
+	if runtimeVersion.ImageTag == "" {
+		runtimeVersion.ImageTag = templateTag
+	}
+
+	return runtimeVersion
+}
+
+// splitImageReference splits a container image reference into its repository and tag. The tag
+// is empty when the reference carries none, and both are empty for a reference pinned by
+// digest, where there is no tag to complete and appending one would not be valid.
+func splitImageReference(image string) (repository string, tag string) {
+	if image == "" || strings.Contains(image, "@") {
+		return "", ""
+	}
+
+	lastColon := strings.LastIndex(image, ":")
+	// A colon before the last slash belongs to a registry port, not to a tag.
+	if lastColon == -1 || lastColon < strings.LastIndex(image, "/") {
+		return image, ""
+	}
+
+	return image[:lastColon], image[lastColon+1:]
+}
+
+// componentTemplateImage returns the image the CacheRuntimeClass declares for a component,
+// which is the baseline a partially specified runtime version is completed against.
+func componentTemplateImage(componentDefinition *datav1alpha1.RuntimeComponentDefinition) string {
+	if componentDefinition == nil || len(componentDefinition.Template.Spec.Containers) == 0 {
+		return ""
+	}
+
+	return componentDefinition.Template.Spec.Containers[0].Image
 }

--- a/pkg/ddc/cache/engine/transform_common_test.go
+++ b/pkg/ddc/cache/engine/transform_common_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("CacheEngine desiredComponentVersion Tests", Label("pkg.ddc.cache.engine.transform_common_test.go"), func() {
+	const templateImage = "btxu/mooncake:v3"
+
+	Describe("desiredComponentVersion", func() {
+		It("should leave a version naming neither half untouched", func() {
+			desired := desiredComponentVersion(datav1alpha1.VersionSpec{}, templateImage)
+
+			Expect(desired.Image).To(BeEmpty())
+			Expect(desired.ImageTag).To(BeEmpty())
+		})
+
+		It("should leave a complete version untouched", func() {
+			desired := desiredComponentVersion(datav1alpha1.VersionSpec{
+				Image:    "other/mooncake",
+				ImageTag: "v9",
+			}, templateImage)
+
+			Expect(desired.Image).To(Equal("other/mooncake"))
+			Expect(desired.ImageTag).To(Equal("v9"))
+		})
+
+		It("should take the repository from the template when only imageTag is named", func() {
+			desired := desiredComponentVersion(datav1alpha1.VersionSpec{ImageTag: "v9"}, templateImage)
+
+			Expect(desired.Image).To(Equal("btxu/mooncake"))
+			Expect(desired.ImageTag).To(Equal("v9"))
+		})
+
+		It("should take the tag from the template when only image is named", func() {
+			desired := desiredComponentVersion(datav1alpha1.VersionSpec{Image: "other/mooncake"}, templateImage)
+
+			Expect(desired.Image).To(Equal("other/mooncake"))
+			Expect(desired.ImageTag).To(Equal("v3"))
+		})
+
+		It("should not carry imagePullPolicy into the completion", func() {
+			desired := desiredComponentVersion(datav1alpha1.VersionSpec{
+				ImageTag:        "v9",
+				ImagePullPolicy: "Always",
+			}, templateImage)
+
+			Expect(desired.ImagePullPolicy).To(Equal("Always"))
+		})
+
+		It("should stay incomplete when the template declares no image", func() {
+			desired := desiredComponentVersion(datav1alpha1.VersionSpec{ImageTag: "v9"}, "")
+
+			Expect(desired.Image).To(BeEmpty())
+			Expect(desired.ImageTag).To(Equal("v9"))
+		})
+
+		It("should stay incomplete when the template pins a digest", func() {
+			desired := desiredComponentVersion(datav1alpha1.VersionSpec{ImageTag: "v9"},
+				"btxu/mooncake@sha256:067614b70d25b496e3edc3480747d558ee8a364ef47a67f669f5d96ca5098552")
+
+			Expect(desired.Image).To(BeEmpty())
+			Expect(desired.ImageTag).To(Equal("v9"))
+		})
+	})
+
+	Describe("splitImageReference", func() {
+		It("should split a plain tagged reference", func() {
+			repository, tag := splitImageReference("btxu/mooncake:v3")
+
+			Expect(repository).To(Equal("btxu/mooncake"))
+			Expect(tag).To(Equal("v3"))
+		})
+
+		It("should report no tag rather than inventing one", func() {
+			repository, tag := splitImageReference("nginx")
+
+			Expect(repository).To(Equal("nginx"))
+			Expect(tag).To(BeEmpty())
+		})
+
+		It("should not mistake a registry port for a tag", func() {
+			repository, tag := splitImageReference("registry.local:5000/mooncake")
+
+			Expect(repository).To(Equal("registry.local:5000/mooncake"))
+			Expect(tag).To(BeEmpty())
+		})
+
+		It("should split a tag off a reference that also carries a registry port", func() {
+			repository, tag := splitImageReference("registry.local:5000/mooncake:v3")
+
+			Expect(repository).To(Equal("registry.local:5000/mooncake"))
+			Expect(tag).To(Equal("v3"))
+		})
+
+		It("should refuse to split a digest reference", func() {
+			repository, tag := splitImageReference("btxu/mooncake@sha256:0676")
+
+			Expect(repository).To(BeEmpty())
+			Expect(tag).To(BeEmpty())
+		})
+	})
+
+	Describe("componentTemplateImage", func() {
+		It("should return an empty image for a nil component definition", func() {
+			Expect(componentTemplateImage(nil)).To(BeEmpty())
+		})
+
+		It("should return an empty image for a template with no containers", func() {
+			Expect(componentTemplateImage(&datav1alpha1.RuntimeComponentDefinition{})).To(BeEmpty())
+		})
+
+		It("should return the first container's image", func() {
+			Expect(componentTemplateImage(&datav1alpha1.RuntimeComponentDefinition{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "worker", Image: templateImage}},
+					},
+				},
+			})).To(Equal(templateImage))
+		})
+	})
+
+	Describe("the creation and the sync path agreeing", func() {
+		It("should resolve an imageTag-only version to the same image on both paths", func() {
+			// creation resolves against the image already on the template copy
+			creationVersion := desiredComponentVersion(datav1alpha1.VersionSpec{ImageTag: "v9"}, templateImage)
+
+			// sync resolves against the CacheRuntimeClass component definition
+			syncVersion := desiredComponentVersion(datav1alpha1.VersionSpec{ImageTag: "v9"},
+				componentTemplateImage(&datav1alpha1.RuntimeComponentDefinition{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "worker", Image: templateImage}},
+						},
+					},
+				}))
+
+			Expect(creationVersion).To(Equal(syncVersion))
+			Expect(creationVersion.Image + ":" + creationVersion.ImageTag).To(Equal("btxu/mooncake:v9"))
+		})
+	})
+})


### PR DESCRIPTION
## What this PR does

Fixes #6178.

`updateImage` refused to touch the workload unless both halves of the image reference were restated on the CacheRuntime:

```go
// pkg/ddc/cache/component/advanced_statefulset_manager.go:268
if version.Image == "" || version.ImageTag == "" {
    return false
}
```

`VersionSpec` declares `image`, `imageTag` and `imagePullPolicy` as three independent optional strings, with no defaults and no validation, so setting only `imageTag` is a legal edit and the obvious way to say "same image, newer build". It did nothing: no patch, no event, no condition, while the CacheRuntime's `generation` still incremented, so from the outside the edit looked accepted.

The creation path already knew how to fall back to the CacheRuntimeClass template when the version is incomplete, so the same value expressed the same intent before and after creation, but only worked before it.

## How

`desiredComponentVersion` completes the missing half from the image the CacheRuntimeClass declares for the component, and both the creation path and `syncRuntimeSpec` call it. A component created with a partial version and one updated to it now resolve to the same image instead of rolling on the next reconcile.

`updateImage` itself is unchanged. Its guard is now a safety net rather than the operative rule.

Two cases are deliberately left alone, because guessing would move the workload onto something nobody asked for:

- a version naming neither half, which keeps the template image
- a version whose missing half cannot be recovered, meaning a template with no image, or one pinned by digest

`splitImageReference` is used rather than `docker.ParseDockerImage` because the latter splits on every colon, which turns a registry with a port and no tag (`registry.example.com:5000/repo`) into a bogus repository and tag pair.

## Unit tests

New `transform_common_test.go` covers `desiredComponentVersion` and `splitImageReference`: tag-only, image-only, both, neither, an empty template image, a digest-pinned template, and a registry with a port.

`pkg/ddc/cache/engine` has 12 failing specs on master already, all in `ufs_test.go` and `sync_test.go` around mount handling. This branch has the same 12 and adds 16 passing ones (243 passed / 12 failed on `f2785f84`, 259 passed / 12 failed here), so the pre-existing failures are untouched by this change.

## Verified on a cluster

kind v0.23.0, Kubernetes v1.30.0, controller built from this branch and loaded into the cluster.

**Creation with only `imageTag`.** Two runs, each with a CacheRuntimeClass whose worker template pins an image and a CacheRuntime naming only a tag:

| Template image | CacheRuntime sets | Resulting AdvancedStatefulSet |
|---|---|---|
| `busybox:1.36` | `worker.runtimeVersion.imageTag: "1.37"` | `busybox:1.37` |
| `mooncake:v3` | `worker.runtimeVersion.imageTag: "v9"` | `mooncake:v9` |

In both runs the master component, which named no `runtimeVersion` at all, stayed on the template image. That is the "neither half named, change nothing" branch.

**Updating a live component to only `imageTag`.** This is the case the issue reports. On a runtime already past setup with a healthy worker, whose spec carried `runtimeVersion: {imageTag: v9}` against a template of `mooncake:v3`, flipping the tag to `v3`:

```
13:19:32.608  advanced_statefulset_manager.go:289  image changed, will update
              old="mooncake:v9"  new="mooncake:v3"
13:19:32.613  advanced_statefulset_manager.go:251  successfully patched advanced statefulset with new spec
```

Both lines carry the same `reconcileID`, and the AdvancedStatefulSet moved to `mooncake:v3` with its generation going 5 to 6 within ten seconds. Before this change the same edit produced no patch at all.

One note on the setup, since it shaped how the second case had to be exercised. A first attempt used an image tag the cluster could not pull, which left the worker in `ImagePullBackOff`; the runtime then never left setup, so `syncRuntimeSpec` was never called and the update path could not be reached at all. That is a property of the test environment rather than of the change, but it is worth knowing that this path only runs once a runtime is past setup.
