### PR TITLE
fix(thin): propagate the transformFuseConfig error in updateFuseConfigOnChange

### DIFF
--- a/pkg/ddc/thin/ufs.go
+++ b/pkg/ddc/thin/ufs.go
@@ -107,7 +107,7 @@ func (t ThinEngine) updateFuseConfigOnChange(runtime *datav1alpha1.ThinRuntime, 
 	updatedThinValue := &ThinValue{}
 	err = t.transformFuseConfig(runtime, dataset, updatedThinValue)
 	if err != nil {
-		return update, nil
+		return update, err
 	}
 
 	fuseConfigMapToUpdate := fuseConfigMap.DeepCopy()

--- a/pkg/ddc/thin/ufs_test.go
+++ b/pkg/ddc/thin/ufs_test.go
@@ -495,6 +495,21 @@ func TestThinEngine_updateFuseConfigOnChange(t *testing.T) {
 			},
 		},
 	}
+	// the referenced PersistentVolumeClaim does not exist, so transformFuseConfig fails
+	pvcDataset := datav1alpha1.Dataset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: datav1alpha1.DatasetSpec{
+			Mounts: []datav1alpha1.Mount{
+				{
+					MountPoint: "pvc://missing-pvc",
+					Name:       "missing-pvc",
+				},
+			},
+		},
+	}
 	thinruntime := datav1alpha1.ThinRuntime{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -528,6 +543,13 @@ func TestThinEngine_updateFuseConfigOnChange(t *testing.T) {
 			cm:         &corev1.ConfigMap{},
 			wantUpdate: false,
 			wantErr:    false,
+		},
+		{
+			name:       "transform fuse config failed",
+			dataset:    &pvcDataset,
+			cm:         &cm,
+			wantUpdate: false,
+			wantErr:    true,
 		},
 	}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`ThinEngine.updateFuseConfigOnChange` (`pkg/ddc/thin/ufs.go`) discards the error returned by `transformFuseConfig`:

```go
updatedThinValue := &ThinValue{}
err = t.transformFuseConfig(runtime, dataset, updatedThinValue)
if err != nil {
	return update, nil     // <- swallows a non-nil err
}
```

Both sibling error paths in the very same function return the error (`kubeclient.GetConfigmapByName` at line 98-100, `kubeclient.UpdateConfigMap` at line 118-120), so this looks like an oversight rather than an intentional choice — `git blame` shows the line was introduced in the same hunk as its correct neighbours by #3432.

The consequence is a lost error signal. The only caller, `ShouldUpdateUFS`, reacts to a non-nil error:

```go
update, err := t.updateFuseConfigOnChange(t.runtime, dataset)
if err != nil {
	t.Log.Error(err, "Failed to update fuse config")
	return
}
```

Because `nil` is returned, that `Log.Error` never fires and the transform failure is completely silent. `transformFuseConfig` is genuinely able to fail here: a `pvc://` mount whose PersistentVolumeClaim is missing or not yet `Bound` makes `extractVolumeInfo` return an error, which is wrapped as `failed to extract volume info from PersistentVolumeClaim "%s"` (`pkg/ddc/thin/transform_config.go:61-64`).

**Scope, stated honestly:** this is an error-swallowing / observability fix, not a behavioural one. `update` is still `false` at that point, so `updateFusePod()` was skipped before this change and is still skipped after it, and `ShouldUpdateUFS` returns a nil `ufsToUpdate` either way. What changes is that the failure is now logged instead of vanishing, and the function no longer holds a latent trap for any future caller that propagates the error.

The fix is one token:

```go
	return update, err
```

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

Added one table case, `"transform fuse config failed"`, to the existing `TestThinEngine_updateFuseConfigOnChange` in `pkg/ddc/thin/ufs_test.go`. It uses a Dataset whose mount is `pvc://missing-pvc` (no such PVC exists in the fake client), so `transformFuseConfig` -> `extractVolumeInfo` -> `kubeclient.GetPersistentVolumeClaim` fails, and asserts `wantUpdate: false, wantErr: true`. The three existing cases are untouched and still pass.

This case fails on `master` and passes with the fix, so it pins the behaviour.

### Ⅳ. Describe how to verify it

All commands run locally on `master` @ `54a41cd` with Go 1.25.7.

**1. The new test fails without the `ufs.go` change (test case applied alone):**

```
$ go test ./pkg/ddc/thin/ -run 'TestThinEngine_updateFuseConfigOnChange' -count=1 -gcflags="all=-N -l" -v
=== RUN   TestThinEngine_updateFuseConfigOnChange
    ufs_test.go:571: testcase transform fuse config failed failed due to error <nil>
--- FAIL: TestThinEngine_updateFuseConfigOnChange (0.00s)
FAIL
FAIL	github.com/fluid-cloudnative/fluid/pkg/ddc/thin	0.360s
```

(`error <nil>` is exactly the symptom: the transform failed, but the function reported success.)

**2. With the fix applied, it passes:**

```
$ go test ./pkg/ddc/thin/ -run 'TestThinEngine_updateFuseConfigOnChange|TestThinEngine_ShouldUpdateUFS' -count=1 -gcflags="all=-N -l" -v
=== RUN   TestThinEngine_ShouldUpdateUFS
=== RUN   TestThinEngine_ShouldUpdateUFS/test
--- PASS: TestThinEngine_ShouldUpdateUFS (0.00s)
    --- PASS: TestThinEngine_ShouldUpdateUFS/test (0.00s)
=== RUN   TestThinEngine_updateFuseConfigOnChange
--- PASS: TestThinEngine_updateFuseConfigOnChange (0.00s)
PASS
ok  	github.com/fluid-cloudnative/fluid/pkg/ddc/thin	0.305s
```

**3. Build, vet and gofmt are clean:**

```
$ go build ./...          # exit 0, no output
$ go vet ./pkg/ddc/thin/...   # exit 0, no output
$ gofmt -l pkg/ddc/thin/      # no output
```

**4. Out-of-band `nilerr` run (this linter is not enabled in the repo's `.golangci.yml`, so CI does not flag it today):**

```
$ golangci-lint run --no-config --default=none -E nilerr ./pkg/ddc/thin/...   # before
pkg\ddc\thin\ufs.go:110:3: error is not nil (line 108) but it returns nil (nilerr)
		return update, nil
		^
1 issues:
* nilerr: 1

$ golangci-lint run --no-config --default=none -E nilerr ./pkg/ddc/thin/...   # after
0 issues.
```

### Ⅴ. Special notes for reviews

- The whole diff is `+23 / -1` across two files; the production change is a single token on `pkg/ddc/thin/ufs.go:110`.
- **Full-package caveat, reported honestly:** `go test ./pkg/ddc/thin/... -count=1` shows 5 failures on my machine (`TestThinEngine_getMountPoint`, `Test_getMountRoot`, and 3 Ginkgo specs in `transform_fuse_test.go`). I verified these are **pre-existing on unmodified `master`** — I stashed my change and got the identical set (`120 Passed | 3 Failed` in the Ginkgo suite both times). They are Windows path-handling artefacts (`getMountRoot() = /thin, want /tmp/thin`) from my local environment, unrelated to this patch. This change adds no new failures.
- `ufs_test.go` uses gomonkey `ApplyFunc`, hence the `-gcflags="all=-N -l"` in the commands above.
- I have not run the e2e suites locally; happy to follow up on anything CI turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
