### PR TITLE
fix(cache): propagate runtime-level podMetadata and imagePullSecrets to component pods

### DIFF
--- a/pkg/ddc/cache/engine/composition_matrix_test.go
+++ b/pkg/ddc/cache/engine/composition_matrix_test.go
@@ -1,0 +1,380 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	workloadv1alpha1 "github.com/fluid-cloudnative/advanced-statefulset/api/workload/v1alpha1"
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// This file is the executable form of the pod-template composition table tracked in #6185.
+//
+// A component's pod template is composed from three layers:
+//
+//	L1  CacheRuntimeClass.topology.<component>.template   (a full PodTemplateSpec)
+//	L2  CacheRuntime.spec.*                               (runtime level, all components)
+//	L3  CacheRuntime.spec.<component>.*                   (component level)
+//
+// Every row below states what each layer declares and what the component must end up
+// with. Each row is then replayed through BOTH code paths that compose those layers:
+//
+//	create  the transform path, which builds the workload from all three layers at once
+//	update  the sync path, which patches a workload created from L1 alone
+//
+// The two paths are written independently (transform_common.go and
+// advanced_statefulset_manager.go) and are expected to agree. A row that passes on one
+// path and fails on the other is a divergence bug, which is the class #6185 is about.
+//
+// Rows carrying a knownBug tag pin CURRENT behaviour, not intended behaviour. Do not
+// read them as an endorsement: each one names the issue that will change it, and the
+// comment states what the row should say once that issue is fixed.
+
+// --- the table ------------------------------------------------------------------
+
+type layerCase struct {
+	// field names the row in the table. Several rows may share a field.
+	field string
+	desc  string
+
+	l1 func(*corev1.PodTemplateSpec)
+	l2 func(*datav1alpha1.CacheRuntimeSpec)
+	l3 func(*datav1alpha1.CacheRuntimeWorkerSpec)
+
+	// want asserts on the pod template the component ends up with, whichever path produced
+	// it. The whole template is handed over, not just the PodSpec, because podMetadata and
+	// imagePullSecrets live on different halves of it.
+	want func(g Gomega, tmpl corev1.PodTemplateSpec)
+
+	// onlyPaths restricts the row to the named paths. Empty means both. Use it only for
+	// fields a path genuinely cannot carry, and say why -- not to silence a divergence.
+	onlyPaths []string
+
+	// knownBug names the issue this row's expectation is wrong under. Non-empty means the
+	// row pins current behaviour so a change to it is visible in review.
+	knownBug string
+}
+
+func compositionTable() []layerCase {
+	return []layerCase{
+		// -- podMetadata: union, later layer wins a key ------------------------------
+		{
+			field: "podMetadata.labels",
+			desc:  "L2 alone reaches the pod",
+			l2: func(s *datav1alpha1.CacheRuntimeSpec) {
+				s.PodMetadata.Labels = map[string]string{"from": "runtime"}
+			},
+			want: func(g Gomega, t corev1.PodTemplateSpec) {
+				g.Expect(t.Labels).To(HaveKeyWithValue("from", "runtime"))
+			},
+			onlyPaths: []string{pathCreate}, // sync path does not patch pod metadata
+		},
+
+		// -- imagePullSecrets: merge by name -----------------------------------------
+		{
+			field: "imagePullSecrets",
+			desc:  "L1 and L2 merge, a name declared twice appears once",
+			l1: func(t *corev1.PodTemplateSpec) {
+				t.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "tmpl"}, {Name: "shared"}}
+			},
+			l2: func(s *datav1alpha1.CacheRuntimeSpec) {
+				s.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "shared"}, {Name: "rt"}}
+			},
+			want: func(g Gomega, t corev1.PodTemplateSpec) {
+				g.Expect(t.Spec.ImagePullSecrets).To(ConsistOf(
+					corev1.LocalObjectReference{Name: "tmpl"},
+					corev1.LocalObjectReference{Name: "shared"},
+					corev1.LocalObjectReference{Name: "rt"}))
+			},
+			onlyPaths: []string{pathCreate},
+		},
+
+		// -- resources: the row #6173 and #6185 turn on ------------------------------
+		{
+			field: "resources",
+			desc:  "L3 restates only limits.memory over an L1 that declares four keys",
+			l1: func(t *corev1.PodTemplateSpec) {
+				t.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+			},
+			l3: func(w *datav1alpha1.CacheRuntimeWorkerSpec) {
+				w.Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("8Gi")},
+				}
+			},
+			// CURRENT: the whole struct is replaced, so the three keys L3 did not restate
+			// are lost and the container ends up with no CPU request or limit at all.
+			// AFTER #6173: requests {cpu 1, memory 2Gi}, limits {cpu 2, memory 8Gi}.
+			knownBug: "#6173",
+			want: func(g Gomega, t corev1.PodTemplateSpec) {
+				r := t.Spec.Containers[0].Resources
+				g.Expect(r.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, resource.MustParse("8Gi")))
+				g.Expect(r.Limits).NotTo(HaveKey(corev1.ResourceCPU))
+				g.Expect(r.Requests).To(BeEmpty())
+			},
+		},
+
+		// -- runtimeVersion: the guard #6178 is about --------------------------------
+		{
+			field: "runtimeVersion",
+			desc:  "L3 sets imageTag only, over an L1 that names an image",
+			l1: func(t *corev1.PodTemplateSpec) {
+				t.Spec.Containers[0].Image = "fluid/cache:v1"
+			},
+			l3: func(w *datav1alpha1.CacheRuntimeWorkerSpec) {
+				w.RuntimeVersion = datav1alpha1.VersionSpec{ImageTag: "v2"}
+			},
+			// CURRENT: the guard wants both image and imageTag, so the tag is dropped.
+			// AFTER #6178: fluid/cache:v2.
+			knownBug: "#6178",
+			want: func(g Gomega, t corev1.PodTemplateSpec) {
+				g.Expect(t.Spec.Containers[0].Image).To(Equal("fluid/cache:v1"))
+			},
+		},
+
+		// -- args vs env: replace on one, append on the other ------------------------
+		{
+			field: "args",
+			desc:  "L3 replaces the template args wholesale",
+			l1: func(t *corev1.PodTemplateSpec) {
+				t.Spec.Containers[0].Args = []string{"--from-template"}
+			},
+			l3: func(w *datav1alpha1.CacheRuntimeWorkerSpec) {
+				w.Args = []string{"--from-component"}
+			},
+			// Intended: the CRD marks args +listType=atomic, so replacing is correct.
+			want: func(g Gomega, t corev1.PodTemplateSpec) {
+				g.Expect(t.Spec.Containers[0].Args).To(Equal([]string{"--from-component"}))
+			},
+			onlyPaths: []string{pathCreate}, // args are not an in-place update field
+		},
+		{
+			field: "env",
+			desc:  "L3 restates a name the template already sets",
+			l1: func(t *corev1.PodTemplateSpec) {
+				t.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "SHARED", Value: "template"}}
+			},
+			l3: func(w *datav1alpha1.CacheRuntimeWorkerSpec) {
+				w.Env = []corev1.EnvVar{{Name: "SHARED", Value: "component"}}
+			},
+			// CURRENT: appended without dedup, so SHARED appears twice. The CRD marks env
+			// +patchStrategy=merge +patchMergeKey=name, which says it should appear once.
+			// Kubernetes takes the last value, so the effective value is already correct.
+			knownBug: "#6185 (env/annotation mismatch)",
+			want: func(g Gomega, t corev1.PodTemplateSpec) {
+				var shared []string
+				for _, e := range t.Spec.Containers[0].Env {
+					if e.Name == "SHARED" {
+						shared = append(shared, e.Value)
+					}
+				}
+				g.Expect(shared).To(Equal([]string{"template", "component"}))
+			},
+			onlyPaths: []string{pathCreate},
+		},
+
+		// -- nodeSelector: implementation and annotation disagree --------------------
+		{
+			field: "nodeSelector",
+			desc:  "L3 sets a key the template does not",
+			l1: func(t *corev1.PodTemplateSpec) {
+				t.Spec.NodeSelector = map[string]string{"tier": "template"}
+			},
+			l3: func(w *datav1alpha1.CacheRuntimeWorkerSpec) {
+				w.NodeSelector = map[string]string{"zone": "a"}
+			},
+			// CURRENT: union, so the template key survives. The CRD marks nodeSelector
+			// +mapType=atomic, which says the whole map should be replaced.
+			knownBug: "#6185 (nodeSelector/annotation mismatch)",
+			want: func(g Gomega, t corev1.PodTemplateSpec) {
+				g.Expect(t.Spec.NodeSelector).To(HaveKeyWithValue("tier", "template"))
+				g.Expect(t.Spec.NodeSelector).To(HaveKeyWithValue("zone", "a"))
+			},
+			onlyPaths: []string{pathCreate},
+		},
+	}
+}
+
+// --- the two paths --------------------------------------------------------------
+
+const (
+	pathCreate = "create (transform)"
+	pathUpdate = "update (sync)"
+)
+
+type compositionPath struct {
+	name string
+	// run applies the three layers and returns the pod template the component ends up with.
+	run func(g Gomega, tc layerCase) corev1.PodTemplateSpec
+}
+
+func baseTemplate() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "worker", Image: "fluid/cache:v1"}},
+		},
+	}
+}
+
+func layersOf(tc layerCase) (corev1.PodTemplateSpec, datav1alpha1.CacheRuntimeSpec) {
+	tmpl := baseTemplate()
+	if tc.l1 != nil {
+		tc.l1(&tmpl)
+	}
+	runtimeSpec := datav1alpha1.CacheRuntimeSpec{RuntimeClassName: "test-class"}
+	if tc.l2 != nil {
+		tc.l2(&runtimeSpec)
+	}
+	worker := datav1alpha1.CacheRuntimeWorkerSpec{Replicas: 1}
+	if tc.l3 != nil {
+		tc.l3(&worker)
+	}
+	runtimeSpec.Worker = worker
+	return tmpl, runtimeSpec
+}
+
+// createPath composes all three layers the way workload creation does.
+var createPath = compositionPath{
+	name: pathCreate,
+	run: func(g Gomega, tc layerCase) corev1.PodTemplateSpec {
+		tmpl, runtimeSpec := layersOf(tc)
+		e := &CacheEngine{name: "test", namespace: "default"}
+
+		value, err := e.initComponentValue(common.ComponentTypeWorker,
+			&datav1alpha1.RuntimeComponentDefinition{Template: tmpl}, nil, runtimeSpec.Worker.Replicas)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		e.transformComponentPodTemplate(runtimeSpec, runtimeSpec.Worker.RuntimeComponentCommonSpec,
+			&datav1alpha1.Dataset{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}, value)
+
+		return value.PodTemplateSpec
+	},
+}
+
+// updatePath seeds a workload built from L1 alone -- the state a CacheRuntime that set
+// nothing would have produced -- then applies L2 and L3 through the sync path and reads
+// the workload back. The end state must match the create path's.
+var updatePath = compositionPath{
+	name: pathUpdate,
+	run: func(g Gomega, tc layerCase) corev1.PodTemplateSpec {
+		tmpl, runtimeSpec := layersOf(tc)
+		name := common.GetCacheComponentName("test", common.ComponentTypeWorker)
+
+		seeded := baseTemplate()
+		if tc.l1 != nil {
+			tc.l1(&seeded)
+		}
+		replicas := int32(1)
+		asts := &workloadv1alpha1.AdvancedStatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: workloadv1alpha1.AdvancedStatefulSetSpec{
+				Replicas: &replicas,
+				Template: seeded,
+			},
+		}
+
+		runtimeObj := &datav1alpha1.CacheRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec:       runtimeSpec,
+		}
+		runtimeClass := &datav1alpha1.CacheRuntimeClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-class"},
+			Topology: &datav1alpha1.RuntimeTopology{
+				Worker: &datav1alpha1.RuntimeComponentDefinition{Template: tmpl},
+			},
+		}
+
+		client := fake.NewClientBuilder().
+			WithScheme(CacheEngineTestScheme).
+			WithObjects(asts, runtimeObj, runtimeClass).
+			Build()
+
+		e := &CacheEngine{
+			name:      "test",
+			namespace: "default",
+			Client:    client,
+			Log:       ctrl.Log.WithName("composition-matrix"),
+		}
+
+		g.Expect(e.syncRuntimeSpec(cruntime.ReconcileRequestContext{}, runtimeObj, runtimeClass)).To(Succeed())
+
+		got := &workloadv1alpha1.AdvancedStatefulSet{}
+		g.Expect(client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: "default"}, got)).To(Succeed())
+		return got.Spec.Template
+	},
+}
+
+// --- the runner -----------------------------------------------------------------
+
+var _ = Describe("CacheRuntime pod template composition matrix",
+	Label("pkg.ddc.cache.engine.composition_matrix_test.go"), func() {
+
+		for _, path := range []compositionPath{createPath, updatePath} {
+			path := path
+
+			Describe(path.name, func() {
+				for _, tc := range compositionTable() {
+					tc := tc
+
+					if !runsOn(tc, path.name) {
+						continue
+					}
+
+					name := tc.field + ": " + tc.desc
+					if tc.knownBug != "" {
+						name += " [pins current behaviour, " + tc.knownBug + "]"
+					}
+
+					It(name, func() {
+						tc.want(Default, path.run(Default, tc))
+					})
+				}
+			})
+		}
+	})
+
+func runsOn(tc layerCase, path string) bool {
+	if len(tc.onlyPaths) == 0 {
+		return true
+	}
+	for _, p := range tc.onlyPaths {
+		if p == path {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ddc/cache/engine/transform_client.go
+++ b/pkg/ddc/cache/engine/transform_client.go
@@ -45,7 +45,7 @@ func (e *CacheEngine) transformClient(dataset *datav1alpha1.Dataset, runtime *da
 	// TODO: TieredStore handling
 
 	// transform container related config, currently only modify the first container
-	e.transformComponentPodTemplate(runtimeClient.RuntimeComponentCommonSpec, dataset, value.Client)
+	e.transformComponentPodTemplate(runtime.Spec, runtimeClient.RuntimeComponentCommonSpec, dataset, value.Client)
 
 	// transform tiered store configuration into pod resource request or volumes .
 	err = e.TransformRuntimeTieredStore(&runtimeClient.TieredStore, &value.Client.PodTemplateSpec.Spec)

--- a/pkg/ddc/cache/engine/transform_common.go
+++ b/pkg/ddc/cache/engine/transform_common.go
@@ -60,18 +60,29 @@ func (e *CacheEngine) initComponentValue(
 }
 
 // transformComponentPodTemplate transforms common pod template configurations for master/worker/client components
-// This includes image, resources, args, env, nodeSelector, tolerations and pod metadata
-func (e *CacheEngine) transformComponentPodTemplate(runtimeCompSpec datav1alpha1.RuntimeComponentCommonSpec,
+// This includes image, resources, args, env, nodeSelector, tolerations, image pull secrets and pod metadata.
+//
+// Fields carried by both runtimeSpec and runtimeCompSpec are layered the way spec.options already is:
+// the CacheRuntimeClass template first, then the runtime-level spec, then the component-level spec.
+func (e *CacheEngine) transformComponentPodTemplate(runtimeSpec datav1alpha1.CacheRuntimeSpec,
+	runtimeCompSpec datav1alpha1.RuntimeComponentCommonSpec,
 	dataset *datav1alpha1.Dataset, componentValue *common.CacheRuntimeComponentValue) {
 	podTemplate := &componentValue.PodTemplateSpec
 
-	// Pod Meta - Labels and Annotations
-	if runtimeCompSpec.PodMetadata.Labels != nil {
-		podTemplate.Labels = utils.UnionMapsWithOverride(podTemplate.Labels, runtimeCompSpec.PodMetadata.Labels)
-	}
-	if runtimeCompSpec.PodMetadata.Annotations != nil {
-		podTemplate.Annotations = utils.UnionMapsWithOverride(podTemplate.Annotations, runtimeCompSpec.PodMetadata.Annotations)
-	}
+	// Pod Meta - Labels and Annotations, template < runtime level < component level.
+	// UnionMapsWithOverride copies both operands, so a nil map at any layer is a no-op.
+	podTemplate.Labels = utils.UnionMapsWithOverride(
+		utils.UnionMapsWithOverride(podTemplate.Labels, runtimeSpec.PodMetadata.Labels),
+		runtimeCompSpec.PodMetadata.Labels)
+	podTemplate.Annotations = utils.UnionMapsWithOverride(
+		utils.UnionMapsWithOverride(podTemplate.Annotations, runtimeSpec.PodMetadata.Annotations),
+		runtimeCompSpec.PodMetadata.Annotations)
+
+	// ImagePullSecrets has no component-level counterpart, so the runtime-level list is merged
+	// onto whatever the template already declares. The CRD marks the field with a merge patch
+	// strategy keyed on name, so a secret named at both layers must not appear twice.
+	podTemplate.Spec.ImagePullSecrets = appendMissingImagePullSecrets(
+		podTemplate.Spec.ImagePullSecrets, runtimeSpec.ImagePullSecrets)
 
 	// transform NodeSelector, runtime component takes higher priority
 	podTemplate.Spec.NodeSelector = utils.UnionMapsWithOverride(podTemplate.Spec.NodeSelector, runtimeCompSpec.NodeSelector)
@@ -147,4 +158,29 @@ func (e *CacheEngine) transformComponentPodTemplate(runtimeCompSpec datav1alpha1
 	if len(componentValue.PodTemplateSpec.Spec.InitContainers) > 0 {
 		componentValue.PodTemplateSpec.Spec.InitContainers[0].Env = append(addEnvs, componentValue.PodTemplateSpec.Spec.InitContainers[0].Env...)
 	}
+}
+
+// appendMissingImagePullSecrets appends the secrets that are not already referenced, comparing
+// by name so that a secret declared both on the CacheRuntimeClass template and on the
+// CacheRuntime is carried once.
+func appendMissingImagePullSecrets(existing []corev1.LocalObjectReference,
+	toAdd []corev1.LocalObjectReference) []corev1.LocalObjectReference {
+	if len(toAdd) == 0 {
+		return existing
+	}
+
+	present := make(map[string]bool, len(existing))
+	for _, secret := range existing {
+		present[secret.Name] = true
+	}
+
+	for _, secret := range toAdd {
+		if present[secret.Name] {
+			continue
+		}
+		present[secret.Name] = true
+		existing = append(existing, secret)
+	}
+
+	return existing
 }

--- a/pkg/ddc/cache/engine/transform_common_test.go
+++ b/pkg/ddc/cache/engine/transform_common_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("CacheEngine Transform Common Tests", Label("pkg.ddc.cache.engine.transform_common_test.go"), func() {
+	var (
+		engine  *CacheEngine
+		dataset *datav1alpha1.Dataset
+	)
+
+	// componentValueWith builds a component value whose PodTemplateSpec stands in for the
+	// CacheRuntimeClass template, which is the first of the three layers.
+	componentValueWith := func(template corev1.PodTemplateSpec) *common.CacheRuntimeComponentValue {
+		if len(template.Spec.Containers) == 0 {
+			template.Spec.Containers = []corev1.Container{{Name: "worker", Image: "fluid/cache:v1"}}
+		}
+		return &common.CacheRuntimeComponentValue{
+			Name:            "test-worker",
+			Namespace:       "default",
+			ComponentType:   common.ComponentTypeWorker,
+			PodTemplateSpec: template,
+		}
+	}
+
+	BeforeEach(func() {
+		engine = &CacheEngine{name: "test", namespace: "default"}
+		dataset = &datav1alpha1.Dataset{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+	})
+
+	Describe("transformComponentPodTemplate pod metadata", func() {
+		It("keeps the template labels and annotations when neither spec sets any", func() {
+			value := componentValueWith(corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"from": "template"},
+					Annotations: map[string]string{"owner": "template"},
+				},
+			})
+
+			engine.transformComponentPodTemplate(datav1alpha1.CacheRuntimeSpec{},
+				datav1alpha1.RuntimeComponentCommonSpec{}, dataset, value)
+
+			Expect(value.PodTemplateSpec.Labels).To(HaveKeyWithValue("from", "template"))
+			Expect(value.PodTemplateSpec.Annotations).To(HaveKeyWithValue("owner", "template"))
+		})
+
+		It("applies the runtime-level pod metadata", func() {
+			value := componentValueWith(corev1.PodTemplateSpec{})
+
+			engine.transformComponentPodTemplate(datav1alpha1.CacheRuntimeSpec{
+				PodMetadata: datav1alpha1.PodMetadata{
+					Labels:      map[string]string{"from": "runtime"},
+					Annotations: map[string]string{"owner": "runtime"},
+				},
+			}, datav1alpha1.RuntimeComponentCommonSpec{}, dataset, value)
+
+			Expect(value.PodTemplateSpec.Labels).To(HaveKeyWithValue("from", "runtime"))
+			Expect(value.PodTemplateSpec.Annotations).To(HaveKeyWithValue("owner", "runtime"))
+		})
+
+		It("applies the component-level pod metadata", func() {
+			value := componentValueWith(corev1.PodTemplateSpec{})
+
+			engine.transformComponentPodTemplate(datav1alpha1.CacheRuntimeSpec{},
+				datav1alpha1.RuntimeComponentCommonSpec{
+					PodMetadata: datav1alpha1.PodMetadata{
+						Labels: map[string]string{"from": "component"},
+					},
+				}, dataset, value)
+
+			Expect(value.PodTemplateSpec.Labels).To(HaveKeyWithValue("from", "component"))
+		})
+
+		It("layers template, runtime level and component level, with the later layer winning a key", func() {
+			value := componentValueWith(corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"only-template": "yes",
+						"shared":        "template",
+					},
+				},
+			})
+
+			engine.transformComponentPodTemplate(datav1alpha1.CacheRuntimeSpec{
+				PodMetadata: datav1alpha1.PodMetadata{
+					Labels: map[string]string{
+						"only-runtime": "yes",
+						"shared":       "runtime",
+					},
+				},
+			}, datav1alpha1.RuntimeComponentCommonSpec{
+				PodMetadata: datav1alpha1.PodMetadata{
+					Labels: map[string]string{
+						"only-component": "yes",
+						"shared":         "component",
+					},
+				},
+			}, dataset, value)
+
+			Expect(value.PodTemplateSpec.Labels).To(HaveKeyWithValue("only-template", "yes"))
+			Expect(value.PodTemplateSpec.Labels).To(HaveKeyWithValue("only-runtime", "yes"))
+			Expect(value.PodTemplateSpec.Labels).To(HaveKeyWithValue("only-component", "yes"))
+			Expect(value.PodTemplateSpec.Labels).To(HaveKeyWithValue("shared", "component"))
+		})
+	})
+
+	Describe("transformComponentPodTemplate image pull secrets", func() {
+		It("keeps the template secrets when the runtime names none", func() {
+			value := componentValueWith(corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "from-template"}},
+				},
+			})
+
+			engine.transformComponentPodTemplate(datav1alpha1.CacheRuntimeSpec{},
+				datav1alpha1.RuntimeComponentCommonSpec{}, dataset, value)
+
+			Expect(value.PodTemplateSpec.Spec.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "from-template"}))
+		})
+
+		It("applies the runtime-level secrets", func() {
+			value := componentValueWith(corev1.PodTemplateSpec{})
+
+			engine.transformComponentPodTemplate(datav1alpha1.CacheRuntimeSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "from-runtime"}},
+			}, datav1alpha1.RuntimeComponentCommonSpec{}, dataset, value)
+
+			Expect(value.PodTemplateSpec.Spec.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "from-runtime"}))
+		})
+
+		It("merges both layers and carries a secret named twice only once", func() {
+			value := componentValueWith(corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{Name: "from-template"},
+						{Name: "shared"},
+					},
+				},
+			})
+
+			engine.transformComponentPodTemplate(datav1alpha1.CacheRuntimeSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: "shared"},
+					{Name: "from-runtime"},
+				},
+			}, datav1alpha1.RuntimeComponentCommonSpec{}, dataset, value)
+
+			Expect(value.PodTemplateSpec.Spec.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "from-template"},
+				corev1.LocalObjectReference{Name: "shared"},
+				corev1.LocalObjectReference{Name: "from-runtime"},
+			))
+		})
+	})
+})

--- a/pkg/ddc/cache/engine/transform_master.go
+++ b/pkg/ddc/cache/engine/transform_master.go
@@ -41,7 +41,7 @@ func (e *CacheEngine) transformMaster(dataset *datav1alpha1.Dataset, runtime *da
 	// TODO: TieredStore handling
 
 	// transform container related config, currently only modify the first container
-	e.transformComponentPodTemplate(runtimeMaster.RuntimeComponentCommonSpec, dataset, value.Master)
+	e.transformComponentPodTemplate(runtime.Spec, runtimeMaster.RuntimeComponentCommonSpec, dataset, value.Master)
 
 	// transform all volume-related configurations
 	err = e.transformVolumes(runtime.Spec.Volumes, runtime.Spec.Master.VolumeMounts, dataset, componentDefinition, commonConfig, true, &value.Master.PodTemplateSpec.Spec)

--- a/pkg/ddc/cache/engine/transform_worker.go
+++ b/pkg/ddc/cache/engine/transform_worker.go
@@ -43,7 +43,7 @@ func (e *CacheEngine) transformWorker(dataset *datav1alpha1.Dataset, runtime *da
 	}
 
 	// transform container related config, currently only modify the first container
-	e.transformComponentPodTemplate(runtimeWorker.RuntimeComponentCommonSpec, dataset, value.Worker)
+	e.transformComponentPodTemplate(runtime.Spec, runtimeWorker.RuntimeComponentCommonSpec, dataset, value.Worker)
 
 	// transform tiered store configuration into pod resource request or volumes .
 	err = e.TransformRuntimeTieredStore(&runtimeWorker.TieredStore, &value.Worker.PodTemplateSpec.Spec)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`CacheRuntimeSpec` has two runtime-level fields whose doc comments say they apply to every
component:

```go
// api/v1alpha1/cacheruntime_types.go:160
// PodMetadata contains labels and annotations that will be propagated to all component pods.
PodMetadata PodMetadata `json:"podMetadata,omitempty"`

// api/v1alpha1/cacheruntime_types.go:164
ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
```

They are in the CRD and the API server takes them, but the transform path does not read
either. `transformComponentPodTemplate` composes a component's pod template from the
CacheRuntimeClass template and the component-level `RuntimeComponentCommonSpec`; the
runtime-level layer is not one of its arguments, so it never enters. Setting both fields on a
CacheRuntime is accepted, and then nothing lands on the pod:

```
imagePullSecrets            = []
labels.from-runtime-level   = []     <- spec.podMetadata
labels.from-component-level = [yes]  <- spec.worker.podMetadata  (control)
annotations.owner           = []     <- spec.podMetadata
```

The component-level control landing is what narrows it: template rendering and the manifest
are fine, only the middle layer goes missing. `imagePullSecrets` is the one likely to hurt —
the kubelet gets no credentials for a component image behind a private registry, and the pull
failure names the image and the registry rather than the field that was dropped, so the runtime
spec is not an obvious place to look.

**Approach.** `podMetadata` has the same three-layer shape as `spec.options`, which already
composes all three layers (`cm.go:146`), so it is given the same order here: CacheRuntimeClass
template < runtime level < component level. `UnionMapsWithOverride` copies both operands and
tolerates nil, so the old `!= nil` guards around the component layer are no longer needed.

`imagePullSecrets` has no component-level counterpart, so there is no precedence to settle.
The runtime-level list is appended onto whatever the template declares, skipping names that
are already there. The CRD marks the field `+patchStrategy=merge +patchMergeKey=name`, which
I read as a name declared at both layers being one entry rather than two. Replacing the
template's list outright would be defensible too, but that seemed more likely to surprise an
owner whose class template already pins a registry secret — happy to switch if maintainers
prefer the simpler rule.

Master, worker and client all go through `transformComponentPodTemplate`, so all three call
sites now pass `runtime.Spec`.

One thing this does not do: both fields are read on the transform path, which runs at setup,
so editing either on a live CacheRuntime still has no effect — `syncRuntimeSpec` handles
`runtimeVersion`, `resources` and `replicas` only. That looks like a separate change, and it
is part of what #6185 is about.

### Ⅱ. Does this pull request fix one issue?

fixes #6184

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

`transform_common_test.go` covers `transformComponentPodTemplate` directly:

- pod metadata — the template's labels and annotations survive when neither spec sets any;
  the runtime level alone reaches the pod; the component level alone reaches the pod; all
  three layers union, and a key declared at more than one layer takes the value from the
  latest one.
- image pull secrets — the template's secrets survive when the runtime names none; the
  runtime-level list alone reaches the pod; both layers merge, and a name declared at both
  appears once.

`composition_matrix_test.go` is the executable form of the composition table in #6185. Each
row states what the three layers declare and what the component should end up with, and every
row is replayed through both paths that compose them — the transform path on create and the
sync path on update — since the two are written independently and are expected to agree.

Rows tagged `knownBug` pin **current** behaviour rather than intended behaviour, so that a
change to any of them shows up in review; each names the issue that will change it and what
it should say afterwards (#6173 for resources, #6178 for `runtimeVersion`, and the
`env`/`nodeSelector` mismatches under #6185). If #6177 merges first, the `#6173` row is the
one that will need updating.

Rows for fields the sync path does not patch are restricted to the create path, which is
stated per row rather than left implicit.

Existing specs in the package are unchanged. The 12 failures in `ufs_test.go` and
`sync_test.go` on this package are present on `master` as well and are unrelated to these
changes.
